### PR TITLE
Display review word count in status bar

### DIFF
--- a/hotcrp-review-mode.el
+++ b/hotcrp-review-mode.el
@@ -178,8 +178,8 @@
              (paper (plist-get pl :paper)))
         (setq hotcrp-review--modeline-string
               (if hotcrp-review-show-modeline
-                  (format " HC R#%s:%dw%s"
-                          paper words (if ok "" (format " (-%d)" rem)))
+                  (format " Words:%d%s"
+                          words (if ok "" (format " (-%d)" rem)))
                 ""))
         (when hotcrp-review-show-header-line-warning
           (setq header-line-format


### PR DESCRIPTION
## Summary
- show current review word count in the mode line for quick reference

## Testing
- `emacs --batch -Q -L . -f batch-byte-compile hotcrp-review-mode.el` *(fails: emacs: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fbe09bd58832582badc8eb92b56d3